### PR TITLE
Feat [#6] 회원가입 프로세스 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,5 +65,5 @@ jobs:
             sudo docker rm -f timetile-server
             sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/timetile-server
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/timetile-server
-            sudo docker run -p 8080:8080 --name timetile-server -d ${{ secrets.DOCKERHUB_USERNAME }}/timetile-server
+            sudo docker run --network host -p 8080:8080 --name timetile-server -d ${{ secrets.DOCKERHUB_USERNAME }}/timetile-server
     

--- a/src/main/java/cotato/timetile/auth/CustomOAuth2UserService.java
+++ b/src/main/java/cotato/timetile/auth/CustomOAuth2UserService.java
@@ -2,12 +2,11 @@ package cotato.timetile.auth;
 
 import cotato.timetile.auth.oauth2.OAuth2UserInfo;
 import cotato.timetile.auth.oauth2.OAuth2UserInfoFactory;
+import cotato.timetile.auth.oauth2.UnregisteredOAuth2User;
 import cotato.timetile.domain.user.domain.AuthProvider;
-import cotato.timetile.domain.user.domain.Role;
 import cotato.timetile.domain.user.domain.User;
 import cotato.timetile.domain.user.persistence.UserRepository;
-import cotato.timetile.global.common.Visibility;
-import cotato.timetile.global.util.NicknameGenerator;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -24,27 +23,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
-        return processUser(userRequest, oAuth2User);
-    }
-
-    private OAuth2User processUser(OAuth2UserRequest oAuth2UserRequest, OAuth2User oAuth2User) {
-        AuthProvider provider = AuthProvider.from(oAuth2UserRequest.getClientRegistration().getRegistrationId());
+        AuthProvider provider = AuthProvider.from(userRequest.getClientRegistration().getRegistrationId());
         OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(provider, oAuth2User.getAttributes());
-        String providerId = oAuth2UserInfo.getId();
-        User user = userRepository.findByProviderAndProviderId(provider, providerId)
-                .orElseGet(() -> registerUser(provider, providerId));
-        return UserPrincipal.of(user);
-    }
-
-    private User registerUser(AuthProvider provider, String providerId) {
-        User user = User.builder()
-                .nickname(NicknameGenerator.generateNickname())
-                .provider(provider)
-                .providerId(providerId)
-                .role(Role.WATCHER)
-                .visibility(Visibility.PUBLIC)
-                .build();
-        return userRepository.save(user);
+        Optional<User> user = userRepository.findByProviderAndProviderId(provider, oAuth2UserInfo.getId());
+        return user
+                .<OAuth2User>map(UserPrincipal::of)
+                .orElseGet(() -> UnregisteredOAuth2User.of(oAuth2UserInfo, provider));
     }
 
 }

--- a/src/main/java/cotato/timetile/auth/UserPrincipal.java
+++ b/src/main/java/cotato/timetile/auth/UserPrincipal.java
@@ -51,7 +51,7 @@ public class UserPrincipal implements UserDetails, OAuth2User {
 
     @Override
     public String getUsername() {
-        return "email";
+        return email;
     }
 
     @Override
@@ -68,5 +68,5 @@ public class UserPrincipal implements UserDetails, OAuth2User {
     public Map<String, Object> getAttributes() {
         return attributes;
     }
-    
+
 }

--- a/src/main/java/cotato/timetile/auth/filter/LocalAuthenticationFilter.java
+++ b/src/main/java/cotato/timetile/auth/filter/LocalAuthenticationFilter.java
@@ -9,6 +9,7 @@ import cotato.timetile.domain.user.api.response.LoginResponse;
 import cotato.timetile.global.common.CommonResponse;
 import cotato.timetile.global.common.SuccessResponse;
 import cotato.timetile.global.exception.UnauthorizedException;
+import cotato.timetile.global.properties.FrontendProperties;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,15 +26,19 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @RequiredArgsConstructor
 public class LocalAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
     private static final String FILTER_PROCESSES_URL = "/api/auth/login";
+    private final FrontendProperties frontendProperties;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final JwtProvider jwtProvider;
 
     public LocalAuthenticationFilter(AuthenticationManager authenticationManager,
                                      CustomLoginFailureHandler customLoginFailureHandler,
-                                     JwtProvider jwtProvider) {
+                                     JwtProvider jwtProvider,
+                                     FrontendProperties frontendProperties) {
         super(authenticationManager);
         this.jwtProvider = jwtProvider;
+        this.frontendProperties = frontendProperties;
         setFilterProcessesUrl(FILTER_PROCESSES_URL);
         setAuthenticationFailureHandler(customLoginFailureHandler);
     }
@@ -60,7 +65,7 @@ public class LocalAuthenticationFilter extends UsernamePasswordAuthenticationFil
         UserPrincipal userDetails = (UserPrincipal) authResult.getPrincipal();
         String refreshToken = jwtProvider.generateRefreshToken(userDetails.getId());
         String accessToken = jwtProvider.generateAccessToken(refreshToken);
-
+        response.sendRedirect(frontendProperties.homeUrl());
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.displayName());

--- a/src/main/java/cotato/timetile/auth/jwt/JwtProvider.java
+++ b/src/main/java/cotato/timetile/auth/jwt/JwtProvider.java
@@ -1,5 +1,8 @@
 package cotato.timetile.auth.jwt;
 
+import cotato.timetile.auth.oauth2.UnregisteredOAuth2User;
+import cotato.timetile.domain.user.api.dto.TemporaryTokenPayloadDto;
+import cotato.timetile.domain.user.domain.AuthProvider;
 import cotato.timetile.domain.user.domain.Role;
 import cotato.timetile.domain.user.persistence.UserRepository;
 import cotato.timetile.global.exception.UnauthorizedException;
@@ -23,6 +26,8 @@ public class JwtProvider {
     private static final Duration ACCESS_TOKEN_VALID_DURATION = Duration.ofHours(3);
     private static final String JWT_TYPE = "JWT";
     private static final String CLAIM_ROLE = "role";
+    private static final String CLAIM_PROVIDER = "provider";
+    private static final String CLAIM_EMAIL = "email";
     private final JwtProperties jwtProperties;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
@@ -86,6 +91,32 @@ public class JwtProvider {
                 .expiration(new Date(now.getTime() + validDuration.toMillis()))
                 .signWith(KeyGenerator.getKeyFromString(jwtProperties.secretKey()))
                 .compact();
+    }
+
+    public String generateTemporaryToken(UnregisteredOAuth2User unregisteredOAuth2User) {
+        Date now = new Date();
+        return Jwts.builder()
+                .header().type(JWT_TYPE).and()
+                .issuedAt(now)
+                .subject(unregisteredOAuth2User.getProviderId())
+                .claim(CLAIM_PROVIDER, unregisteredOAuth2User.getProvider())
+                .claim(CLAIM_EMAIL, unregisteredOAuth2User.getEmail())
+                .expiration(new Date(now.getTime() + Duration.ofMinutes(30).toMillis()))
+                .signWith(KeyGenerator.getKeyFromString(jwtProperties.secretKey()))
+                .compact();
+    }
+
+    public TemporaryTokenPayloadDto parseFromTemporaryToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(KeyGenerator.getKeyFromString(jwtProperties.secretKey()))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return TemporaryTokenPayloadDto.of(
+                claims.get(CLAIM_EMAIL, String.class),
+                AuthProvider.from(claims.get(CLAIM_PROVIDER, String.class)),
+                claims.getSubject()
+        );
     }
 
 }

--- a/src/main/java/cotato/timetile/auth/oauth2/GoogleOAuth2UserInfo.java
+++ b/src/main/java/cotato/timetile/auth/oauth2/GoogleOAuth2UserInfo.java
@@ -12,5 +12,10 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
     public String getId() {
         return attributes.get("sub").toString();
     }
+
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
     
 }

--- a/src/main/java/cotato/timetile/auth/oauth2/KakaoOAuth2UserInfo.java
+++ b/src/main/java/cotato/timetile/auth/oauth2/KakaoOAuth2UserInfo.java
@@ -12,5 +12,11 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
     public String getId() {
         return attributes.get("id").toString();
     }
-    
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        return kakaoAccount.get("email").toString();
+    }
+
 }

--- a/src/main/java/cotato/timetile/auth/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/cotato/timetile/auth/oauth2/OAuth2LoginSuccessHandler.java
@@ -6,6 +6,7 @@ import cotato.timetile.auth.jwt.JwtProvider;
 import cotato.timetile.domain.user.api.response.LoginResponse;
 import cotato.timetile.global.common.CommonResponse;
 import cotato.timetile.global.common.SuccessResponse;
+import cotato.timetile.global.properties.FrontendProperties;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
+    private final FrontendProperties frontendProperties;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final JwtProvider jwtProvider;
 
@@ -27,16 +29,23 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
                                         Authentication authentication) throws IOException {
-        UserPrincipal oAuth2User = (UserPrincipal) authentication.getPrincipal();
-        Long userId = oAuth2User.getId();
-        String refreshToken = jwtProvider.generateRefreshToken(userId);
-        String accessToken = jwtProvider.generateAccessToken(refreshToken);
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UnregisteredOAuth2User unregisteredOAuth2User) {
+            String temporaryToken = jwtProvider.generateTemporaryToken(unregisteredOAuth2User);
+            response.sendRedirect(frontendProperties.registerUrl() + temporaryToken);
+            response.setStatus(HttpServletResponse.SC_OK);
+        } else if (principal instanceof UserPrincipal oAuth2User) {
+            Long userId = oAuth2User.getId();
+            String refreshToken = jwtProvider.generateRefreshToken(userId);
+            String accessToken = jwtProvider.generateAccessToken(refreshToken);
+            response.sendRedirect(frontendProperties.homeUrl());
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.displayName());
+            response.getWriter().write(objectMapper.writeValueAsString(CommonResponse.success(
+                    SuccessResponse.OK, LoginResponse.of(accessToken, refreshToken))));
+        }
 
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding(StandardCharsets.UTF_8.displayName());
-        response.getWriter().write(objectMapper.writeValueAsString(CommonResponse.success(
-                SuccessResponse.OK, LoginResponse.of(accessToken, refreshToken))));
     }
 
 }

--- a/src/main/java/cotato/timetile/auth/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/cotato/timetile/auth/oauth2/OAuth2UserInfo.java
@@ -11,5 +11,7 @@ public abstract class OAuth2UserInfo {
     }
 
     public abstract String getId();
-    
+
+    public abstract String getEmail();
+
 }

--- a/src/main/java/cotato/timetile/auth/oauth2/UnregisteredOAuth2User.java
+++ b/src/main/java/cotato/timetile/auth/oauth2/UnregisteredOAuth2User.java
@@ -1,0 +1,35 @@
+package cotato.timetile.auth.oauth2;
+
+import cotato.timetile.domain.user.domain.AuthProvider;
+import java.util.Collection;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@AllArgsConstructor
+@Getter
+public class UnregisteredOAuth2User implements OAuth2User {
+
+    private String providerId;
+    private AuthProvider provider;
+    private String email;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public static UnregisteredOAuth2User of(OAuth2UserInfo oAuth2UserInfo, AuthProvider provider) {
+        return new UnregisteredOAuth2User(oAuth2UserInfo.getId(), provider, oAuth2UserInfo.getEmail(), null, null);
+    }
+
+    @Override
+    public String getName() {
+        return providerId;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+}

--- a/src/main/java/cotato/timetile/domain/term/api/TermController.java
+++ b/src/main/java/cotato/timetile/domain/term/api/TermController.java
@@ -1,0 +1,27 @@
+package cotato.timetile.domain.term.api;
+
+import cotato.timetile.domain.term.application.TermLoadService;
+import cotato.timetile.global.common.CommonResponse;
+import cotato.timetile.global.common.SuccessResponse;
+import cotato.timetile.global.util.ApiResponseUtil;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/terms")
+@RequiredArgsConstructor
+@Tag(name = "약관")
+public class TermController {
+
+    private final TermLoadService termLoadService;
+
+    @GetMapping
+    public ResponseEntity<CommonResponse<?>> load() {
+        return ApiResponseUtil.success(SuccessResponse.OK, termLoadService.load());
+    }
+
+}

--- a/src/main/java/cotato/timetile/domain/term/api/dto/TermLoadDto.java
+++ b/src/main/java/cotato/timetile/domain/term/api/dto/TermLoadDto.java
@@ -1,0 +1,19 @@
+package cotato.timetile.domain.term.api.dto;
+
+import cotato.timetile.domain.term.domain.Term;
+
+public record TermLoadDto(
+        Long id,
+        String title,
+        String content,
+        boolean required
+) {
+    public static TermLoadDto of(Term term) {
+        return new TermLoadDto(
+                term.getId(),
+                term.getTitle(),
+                term.getContent(),
+                term.isRequired()
+        );
+    }
+}

--- a/src/main/java/cotato/timetile/domain/term/api/response/TermLoadResponse.java
+++ b/src/main/java/cotato/timetile/domain/term/api/response/TermLoadResponse.java
@@ -1,0 +1,12 @@
+package cotato.timetile.domain.term.api.response;
+
+import cotato.timetile.domain.term.api.dto.TermLoadDto;
+import java.util.List;
+
+public record TermLoadResponse(
+        List<TermLoadDto> terms
+) {
+    public static TermLoadResponse of(List<TermLoadDto> terms) {
+        return new TermLoadResponse(terms);
+    }
+}

--- a/src/main/java/cotato/timetile/domain/term/application/TermLoadService.java
+++ b/src/main/java/cotato/timetile/domain/term/application/TermLoadService.java
@@ -1,0 +1,23 @@
+package cotato.timetile.domain.term.application;
+
+import cotato.timetile.domain.term.api.dto.TermLoadDto;
+import cotato.timetile.domain.term.api.response.TermLoadResponse;
+import cotato.timetile.domain.term.persistence.TermRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TermLoadService {
+
+    private final TermRepository termRepository;
+
+    public TermLoadResponse load() {
+        return TermLoadResponse.of(
+                termRepository.findLatestTerms().stream()
+                        .map(TermLoadDto::of)
+                        .toList()
+        );
+    }
+
+}

--- a/src/main/java/cotato/timetile/domain/term/domain/Term.java
+++ b/src/main/java/cotato/timetile/domain/term/domain/Term.java
@@ -1,0 +1,45 @@
+package cotato.timetile.domain.term.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Table(name = "terms")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+public class Term {
+
+    @Id
+    @Column(nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    private boolean required;
+
+    @Column(nullable = false)
+    private String version;
+
+    @Column(nullable = false, updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/cotato/timetile/domain/term/persistence/TermRepository.java
+++ b/src/main/java/cotato/timetile/domain/term/persistence/TermRepository.java
@@ -1,0 +1,23 @@
+package cotato.timetile.domain.term.persistence;
+
+import cotato.timetile.domain.term.domain.Term;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TermRepository extends JpaRepository<Term, Long> {
+
+    @Query(value = """
+            SELECT *
+            FROM (
+                SELECT *, ROW_NUMBER() OVER (PARTITION BY title ORDER BY version DESC) as rn
+                FROM terms
+            ) ranked
+            WHERE rn = 1
+            ORDER BY id
+            """, nativeQuery = true)
+    List<Term> findLatestTerms();
+
+}

--- a/src/main/java/cotato/timetile/domain/user/api/OAuth2SignupController.java
+++ b/src/main/java/cotato/timetile/domain/user/api/OAuth2SignupController.java
@@ -1,0 +1,33 @@
+package cotato.timetile.domain.user.api;
+
+import cotato.timetile.domain.user.api.request.OAuth2SignupRequest;
+import cotato.timetile.domain.user.application.OAuth2SignupService;
+import cotato.timetile.global.common.CommonResponse;
+import cotato.timetile.global.common.SuccessResponse;
+import cotato.timetile.global.util.ApiResponseUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/auth")
+@RequiredArgsConstructor
+@Tag(name = "OAuth2 회원 가입")
+public class OAuth2SignupController {
+
+    private final OAuth2SignupService oAuth2SignupService;
+
+    @PostMapping("/oauth2/signup")
+    @Operation(summary = "회원 가입")
+    public ResponseEntity<CommonResponse<?>> signup(@Valid @RequestBody OAuth2SignupRequest request) {
+        oAuth2SignupService.register(request);
+        return ApiResponseUtil.success(SuccessResponse.CREATED);
+    }
+
+}

--- a/src/main/java/cotato/timetile/domain/user/api/UserFileController.java
+++ b/src/main/java/cotato/timetile/domain/user/api/UserFileController.java
@@ -1,0 +1,32 @@
+package cotato.timetile.domain.user.api;
+
+import cotato.timetile.domain.user.api.request.UserLoadFileUrlRequest;
+import cotato.timetile.domain.user.application.UserFileService;
+import cotato.timetile.global.common.CommonResponse;
+import cotato.timetile.global.common.SuccessResponse;
+import cotato.timetile.global.util.ApiResponseUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/users/files")
+@RequiredArgsConstructor
+@Tag(name = "유저")
+public class UserFileController {
+
+    private final UserFileService userFileService;
+
+    @GetMapping
+    @Operation(summary = "업로드 URL 조회")
+    public ResponseEntity<CommonResponse<?>> loadUrl(@Valid @RequestBody UserLoadFileUrlRequest request) {
+        return ApiResponseUtil.success(SuccessResponse.OK, userFileService.loadUrl(request));
+    }
+
+}

--- a/src/main/java/cotato/timetile/domain/user/api/dto/TemporaryTokenPayloadDto.java
+++ b/src/main/java/cotato/timetile/domain/user/api/dto/TemporaryTokenPayloadDto.java
@@ -1,0 +1,13 @@
+package cotato.timetile.domain.user.api.dto;
+
+import cotato.timetile.domain.user.domain.AuthProvider;
+
+public record TemporaryTokenPayloadDto(
+        String email,
+        AuthProvider provider,
+        String providerId
+) {
+    public static TemporaryTokenPayloadDto of(String email, AuthProvider provider, String providerId) {
+        return new TemporaryTokenPayloadDto(email, provider, providerId);
+    }
+}

--- a/src/main/java/cotato/timetile/domain/user/api/dto/UserCreationDto.java
+++ b/src/main/java/cotato/timetile/domain/user/api/dto/UserCreationDto.java
@@ -1,0 +1,39 @@
+package cotato.timetile.domain.user.api.dto;
+
+import cotato.timetile.domain.user.api.request.LocalSignupRequest;
+import cotato.timetile.domain.user.api.request.OAuth2SignupRequest;
+import cotato.timetile.domain.user.domain.AuthProvider;
+
+public record UserCreationDto(
+        String email,
+        String password,
+        String nickname,
+        String introduction,
+        String imageKey,
+        AuthProvider provider,
+        String providerId
+) {
+    public static UserCreationDto of(LocalSignupRequest request) {
+        return new UserCreationDto(
+                request.email(),
+                request.password(),
+                request.nickname(),
+                request.introduction(),
+                request.imageKey(),
+                AuthProvider.LOCAL,
+                null
+        );
+    }
+
+    public static UserCreationDto of(OAuth2SignupRequest request, TemporaryTokenPayloadDto dto) {
+        return new UserCreationDto(
+                dto.email(),
+                null,
+                request.nickname(),
+                request.introduction(),
+                request.imageKey(),
+                dto.provider(),
+                dto.providerId()
+        );
+    }
+}

--- a/src/main/java/cotato/timetile/domain/user/api/request/LocalSignupRequest.java
+++ b/src/main/java/cotato/timetile/domain/user/api/request/LocalSignupRequest.java
@@ -1,28 +1,17 @@
 package cotato.timetile.domain.user.api.request;
 
-import cotato.timetile.domain.user.domain.AuthProvider;
-import cotato.timetile.domain.user.domain.Role;
-import cotato.timetile.domain.user.domain.User;
-import cotato.timetile.global.common.Visibility;
-import cotato.timetile.global.util.EncryptUtil;
-import cotato.timetile.global.util.NicknameGenerator;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import java.util.List;
 
 public record LocalSignupRequest(
         @Email @NotBlank String email,
         @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+{}\\[\\]:;\"'<>?,./\\\\|`~\\-])[A-Za-z\\d!@#$%^&*()_+{}\\[\\]:;\"'<>?,./\\\\|`~\\-]{6,19}$")
-        @NotBlank String password
+        @NotBlank String password,
+        @NotBlank String nickname,
+        String introduction,
+        String imageKey,
+        List<Long> agreementIds
 ) {
-    public User toUser() {
-        return User.builder()
-                .email(email)
-                .password(EncryptUtil.encrypt(password))
-                .nickname(NicknameGenerator.generateNickname())
-                .provider(AuthProvider.LOCAL)
-                .role(Role.WATCHER)
-                .visibility(Visibility.PUBLIC)
-                .build();
-    }
 }

--- a/src/main/java/cotato/timetile/domain/user/api/request/OAuth2SignupRequest.java
+++ b/src/main/java/cotato/timetile/domain/user/api/request/OAuth2SignupRequest.java
@@ -1,0 +1,13 @@
+package cotato.timetile.domain.user.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record OAuth2SignupRequest(
+        @NotBlank String temporaryToken,
+        @NotBlank String nickname,
+        String introduction,
+        String imageKey,
+        List<Long> agreementIds
+) {
+}

--- a/src/main/java/cotato/timetile/domain/user/api/request/UserLoadFileUrlRequest.java
+++ b/src/main/java/cotato/timetile/domain/user/api/request/UserLoadFileUrlRequest.java
@@ -1,0 +1,8 @@
+package cotato.timetile.domain.user.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserLoadFileUrlRequest(
+        @NotBlank String extension
+) {
+}

--- a/src/main/java/cotato/timetile/domain/user/api/response/UserLoadFileUrlResponse.java
+++ b/src/main/java/cotato/timetile/domain/user/api/response/UserLoadFileUrlResponse.java
@@ -1,0 +1,10 @@
+package cotato.timetile.domain.user.api.response;
+
+public record UserLoadFileUrlResponse(
+        String key,
+        String url
+) {
+    public static UserLoadFileUrlResponse of(String key, String url) {
+        return new UserLoadFileUrlResponse(key, url);
+    }
+}

--- a/src/main/java/cotato/timetile/domain/user/application/LocalSignupService.java
+++ b/src/main/java/cotato/timetile/domain/user/application/LocalSignupService.java
@@ -1,15 +1,25 @@
 package cotato.timetile.domain.user.application;
 
 import cotato.timetile.auth.mail.MailSender;
+import cotato.timetile.domain.term.domain.Term;
+import cotato.timetile.domain.term.persistence.TermRepository;
+import cotato.timetile.domain.user.api.dto.UserCreationDto;
 import cotato.timetile.domain.user.api.request.EmailCheckRequest;
 import cotato.timetile.domain.user.api.request.EmailVerificationRequest;
 import cotato.timetile.domain.user.api.request.LocalSignupRequest;
 import cotato.timetile.domain.user.api.response.EmailCheckResponse;
 import cotato.timetile.domain.user.api.response.EmailVerificationResponse;
+import cotato.timetile.domain.user.domain.User;
+import cotato.timetile.domain.user.domain.UserTermAgreement;
 import cotato.timetile.domain.user.persistence.UserRepository;
+import cotato.timetile.global.exception.BadRequestException;
+import cotato.timetile.global.exception.UnauthorizedException;
 import cotato.timetile.global.handler.RedisHandler;
+import cotato.timetile.global.handler.S3Handler;
 import cotato.timetile.global.util.VerificationCodeGenerator;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +29,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class LocalSignupService {
 
     private final UserRepository userRepository;
+    private final TermRepository termRepository;
     private final MailSender mailSender;
     private final RedisHandler redisHandler;
+    private final S3Handler s3Handler;
     private static final int CODE_VALID_DURATION = 3;
+    private static final int VERIFIED_VALID_DURATION = 30;
 
     @Transactional(readOnly = true)
     public EmailCheckResponse checkEmail(EmailCheckRequest request) {
@@ -35,13 +48,38 @@ public class LocalSignupService {
     }
 
     public EmailVerificationResponse verifyEmail(EmailVerificationRequest request) {
-        return EmailVerificationResponse.of(
-                redisHandler.get(request.email()).toString().equals(request.verificationCode()));
+        boolean isValid = redisHandler.get(request.email()) != null &&
+                redisHandler.get(request.email()).toString().equals(request.verificationCode());
+        if (isValid) {
+            redisHandler.set(request.email(), "true", Duration.ofMinutes(VERIFIED_VALID_DURATION));
+        }
+        return EmailVerificationResponse.of(isValid);
     }
 
     @Transactional
     public void register(LocalSignupRequest request) {
-        userRepository.save(request.toUser());
+        boolean isVerified = redisHandler.get(request.email()) != null &&
+                redisHandler.get(request.email()).equals("true");
+        if (!isVerified) {
+            throw UnauthorizedException.unverified();
+        }
+        validateRequiredTermsAgreed(request.agreementIds());
+        s3Handler.deleteNotAllowedFiles(List.of(request.imageKey()));
+        User user = User.of(UserCreationDto.of(request));
+        termRepository.findAllById(request.agreementIds())
+                .forEach(term -> user.agree(UserTermAgreement.of(user, term)));
+        userRepository.save(user);
+    }
+
+    private void validateRequiredTermsAgreed(List<Long> agreementIds) {
+        List<Long> requiredTermIds = termRepository.findLatestTerms().stream()
+                .filter(Term::isRequired)
+                .map(Term::getId)
+                .toList();
+
+        if (!new HashSet<>(agreementIds).containsAll(requiredTermIds)) {
+            throw BadRequestException.wrong();
+        }
     }
 
 }

--- a/src/main/java/cotato/timetile/domain/user/application/OAuth2SignupService.java
+++ b/src/main/java/cotato/timetile/domain/user/application/OAuth2SignupService.java
@@ -1,0 +1,52 @@
+package cotato.timetile.domain.user.application;
+
+import cotato.timetile.auth.jwt.JwtProvider;
+import cotato.timetile.domain.term.domain.Term;
+import cotato.timetile.domain.term.persistence.TermRepository;
+import cotato.timetile.domain.user.api.dto.UserCreationDto;
+import cotato.timetile.domain.user.api.request.OAuth2SignupRequest;
+import cotato.timetile.domain.user.domain.User;
+import cotato.timetile.domain.user.domain.UserTermAgreement;
+import cotato.timetile.domain.user.persistence.UserRepository;
+import cotato.timetile.global.exception.BadRequestException;
+import cotato.timetile.global.handler.S3Handler;
+import java.util.HashSet;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2SignupService {
+
+    private final UserRepository userRepository;
+    private final TermRepository termRepository;
+    private final JwtProvider jwtProvider;
+    private final S3Handler s3Handler;
+
+    @Transactional
+    public void register(OAuth2SignupRequest request) {
+        validateRequiredTermsAgreed(request.agreementIds());
+        s3Handler.deleteNotAllowedFiles(List.of(request.imageKey()));
+        User user = User.of(UserCreationDto.of(
+                request,
+                jwtProvider.parseFromTemporaryToken(request.temporaryToken()))
+        );
+        termRepository.findAllById(request.agreementIds())
+                .forEach(term -> user.agree(UserTermAgreement.of(user, term)));
+        userRepository.save(user);
+    }
+
+    private void validateRequiredTermsAgreed(List<Long> agreementIds) {
+        List<Long> requiredTermIds = termRepository.findLatestTerms().stream()
+                .filter(Term::isRequired)
+                .map(Term::getId)
+                .toList();
+
+        if (!new HashSet<>(agreementIds).containsAll(requiredTermIds)) {
+            throw BadRequestException.wrong();
+        }
+    }
+
+}

--- a/src/main/java/cotato/timetile/domain/user/application/UserFileService.java
+++ b/src/main/java/cotato/timetile/domain/user/application/UserFileService.java
@@ -1,0 +1,22 @@
+package cotato.timetile.domain.user.application;
+
+import cotato.timetile.domain.user.api.request.UserLoadFileUrlRequest;
+import cotato.timetile.domain.user.api.response.UserLoadFileUrlResponse;
+import cotato.timetile.global.common.S3Folder;
+import cotato.timetile.global.handler.S3Handler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserFileService {
+
+    private final S3Handler s3Handler;
+
+    public UserLoadFileUrlResponse loadUrl(UserLoadFileUrlRequest request) {
+        String key = s3Handler.generateKey(request.extension(), S3Folder.USER);
+        String url = s3Handler.generateSignedPutUrl(key);
+        return UserLoadFileUrlResponse.of(key, url);
+    }
+    
+}

--- a/src/main/java/cotato/timetile/domain/user/domain/AuthProvider.java
+++ b/src/main/java/cotato/timetile/domain/user/domain/AuthProvider.java
@@ -1,11 +1,13 @@
 package cotato.timetile.domain.user.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import cotato.timetile.global.exception.AuthenticationProviderException;
 import java.util.Arrays;
 
 public enum AuthProvider {
     LOCAL, GOOGLE, KAKAO;
 
+    @JsonCreator
     public static AuthProvider from(String name) {
         return Arrays.stream(values())
                 .filter(p -> p.name().equalsIgnoreCase(name))

--- a/src/main/java/cotato/timetile/domain/user/domain/User.java
+++ b/src/main/java/cotato/timetile/domain/user/domain/User.java
@@ -7,8 +7,10 @@ import cotato.timetile.domain.event.domain.Event;
 import cotato.timetile.domain.post.domain.Post;
 import cotato.timetile.domain.post.domain.PostLike;
 import cotato.timetile.domain.scrap.domain.ScrapFolder;
+import cotato.timetile.domain.user.api.dto.UserCreationDto;
 import cotato.timetile.global.common.TimeInfo;
 import cotato.timetile.global.common.Visibility;
+import cotato.timetile.global.util.EncryptUtil;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -100,6 +102,23 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<ArtistFollow> artistFollows = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<UserTermAgreement> agreements = new ArrayList<>();
+
+    public static User of(UserCreationDto dto) {
+        return User.builder()
+                .email(dto.email())
+                .password(dto.password() != null ? EncryptUtil.encrypt(dto.password()) : null)
+                .nickname(dto.nickname())
+                .introduction(dto.introduction())
+                .imageKey(dto.imageKey())
+                .provider(dto.provider())
+                .providerId(dto.providerId())
+                .role(Role.WATCHER)
+                .visibility(Visibility.PUBLIC)
+                .build();
+    }
+
     public void updateProfile(String nickname, String introduction, String imageKey) {
         if (StringUtils.hasText(nickname)) {
             this.nickname = nickname;
@@ -166,6 +185,10 @@ public class User {
 
     public void unfollow(ArtistFollow artistFollow) {
         this.artistFollows.remove(artistFollow);
+    }
+
+    public void agree(UserTermAgreement userTermAgreement) {
+        this.agreements.add(userTermAgreement);
     }
 
     public void increaseFollowingCount() {

--- a/src/main/java/cotato/timetile/domain/user/domain/UserTermAgreement.java
+++ b/src/main/java/cotato/timetile/domain/user/domain/UserTermAgreement.java
@@ -1,0 +1,52 @@
+package cotato.timetile.domain.user.domain;
+
+import cotato.timetile.domain.term.domain.Term;
+import cotato.timetile.global.common.TimeInfo;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "user_term_agreements")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+public class UserTermAgreement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id")
+    private Term term;
+
+    @Embedded
+    private TimeInfo timeInfo;
+
+    public static UserTermAgreement of(User user, Term term) {
+        return UserTermAgreement.builder()
+                .user(user)
+                .term(term)
+                .build();
+    }
+
+}

--- a/src/main/java/cotato/timetile/global/common/ErrorResponse.java
+++ b/src/main/java/cotato/timetile/global/common/ErrorResponse.java
@@ -11,6 +11,7 @@ public enum ErrorResponse {
 
     INVALID_USER(HttpStatus.UNAUTHORIZED, "AUTH001", "존재하지 않는 유저"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH002", "유효하지 않은 토큰"),
+    UNVERIFIED_USER(HttpStatus.UNAUTHORIZED, "AUTH002", "인증되지 않음"),
 
     INVALID_PROVIDER(HttpStatus.FORBIDDEN, "AUTH003", "유효하지 않은 로그인 방식"),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH004", "접근 권한 없음"),

--- a/src/main/java/cotato/timetile/global/config/SecurityConfig.java
+++ b/src/main/java/cotato/timetile/global/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import cotato.timetile.auth.filter.JwtAuthenticationFilter;
 import cotato.timetile.auth.filter.LocalAuthenticationFilter;
 import cotato.timetile.auth.jwt.JwtProvider;
 import cotato.timetile.auth.oauth2.OAuth2LoginSuccessHandler;
+import cotato.timetile.global.properties.FrontendProperties;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -44,6 +45,7 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtProvider jwtProvider;
+    private final FrontendProperties frontendProperties;
 
     private static final String[] AUTH_WHITELIST = {
             "/**"
@@ -91,7 +93,8 @@ public class SecurityConfig {
 
     @Bean
     public LocalAuthenticationFilter localAuthenticationFilter(AuthenticationManager authenticationManager) {
-        return new LocalAuthenticationFilter(authenticationManager, customLoginFailureHandler, jwtProvider);
+        return new LocalAuthenticationFilter(authenticationManager, customLoginFailureHandler, jwtProvider,
+                frontendProperties);
     }
 
     @Bean

--- a/src/main/java/cotato/timetile/global/exception/UnauthorizedException.java
+++ b/src/main/java/cotato/timetile/global/exception/UnauthorizedException.java
@@ -16,4 +16,8 @@ public class UnauthorizedException extends CustomException {
         return new UnauthorizedException(ErrorResponse.INVALID_TOKEN);
     }
 
+    public static UnauthorizedException unverified() {
+        return new UnauthorizedException(ErrorResponse.UNVERIFIED_USER);
+    }
+
 }

--- a/src/main/java/cotato/timetile/global/properties/FrontendProperties.java
+++ b/src/main/java/cotato/timetile/global/properties/FrontendProperties.java
@@ -1,0 +1,10 @@
+package cotato.timetile.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "frontend")
+public record FrontendProperties(
+        String homeUrl,
+        String registerUrl
+) {
+}

--- a/src/main/java/cotato/timetile/global/properties/FrontendPropertiesConfiguration.java
+++ b/src/main/java/cotato/timetile/global/properties/FrontendPropertiesConfiguration.java
@@ -1,0 +1,9 @@
+package cotato.timetile.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan(basePackages = "cotato.timetile.global.properties")
+public class FrontendPropertiesConfiguration {
+}


### PR DESCRIPTION
<!-- 제목 양식 : prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 확인 --> 

## 🎉 Issue Number
<!-- #{본인 이슈 번호}로 이슈가 연결됩니다 -->
closes #6 

## ✅ Done
<!-- 본인이 한 업무 -->

- [x] 약관 동의 -> OAuth2/로컬 회원가입 -> 추가 정보 입력의 3단계로 이루어지도록 변경

## ✍️ Description
<!-- 본인이 한 작업 설명 -->
<!-- 고민, 개선사항 포함 -->
- 로컬 회원가입 시, 이메일 인증이 된 이메일만 가입할 수 있도록 검증 로직을 추가했습니다.
- OAuth2 회원가입 시, 이메일 인증을 따로 진행하지 않기 때문에, 인가 후, 임시 토큰을 발급하여 보완했습니다.