### PR TITLE
Fix [#9] 허용되지 않는 이미지 삭제 시 null 처리

### DIFF
--- a/src/main/java/cotato/timetile/domain/user/application/LocalSignupService.java
+++ b/src/main/java/cotato/timetile/domain/user/application/LocalSignupService.java
@@ -64,7 +64,7 @@ public class LocalSignupService {
             throw UnauthorizedException.unverified();
         }
         validateRequiredTermsAgreed(request.agreementIds());
-        s3Handler.deleteNotAllowedFiles(List.of(request.imageKey()));
+        s3Handler.deleteNotAllowedFile(request.imageKey());
         User user = User.of(UserCreationDto.of(request));
         termRepository.findAllById(request.agreementIds())
                 .forEach(term -> user.agree(UserTermAgreement.of(user, term)));

--- a/src/main/java/cotato/timetile/domain/user/application/OAuth2SignupService.java
+++ b/src/main/java/cotato/timetile/domain/user/application/OAuth2SignupService.java
@@ -28,7 +28,7 @@ public class OAuth2SignupService {
     @Transactional
     public void register(OAuth2SignupRequest request) {
         validateRequiredTermsAgreed(request.agreementIds());
-        s3Handler.deleteNotAllowedFiles(List.of(request.imageKey()));
+        s3Handler.deleteNotAllowedFile(request.imageKey());
         User user = User.of(UserCreationDto.of(
                 request,
                 jwtProvider.parseFromTemporaryToken(request.temporaryToken()))

--- a/src/main/java/cotato/timetile/global/handler/S3Handler.java
+++ b/src/main/java/cotato/timetile/global/handler/S3Handler.java
@@ -77,6 +77,17 @@ public class S3Handler {
                 .toString();
     }
 
+    public void deleteNotAllowedFile(String mediaKey) {
+        if (mediaKey == null) {
+            return;
+        }
+        if (validateMetadata(mediaKey)) {
+            return;
+        }
+        deleteFile(mediaKey);
+        throw UnprocessableEntityException.invalid();
+    }
+
     public void deleteNotAllowedFiles(List<String> mediaKeys) {
         List<String> invalidMediaKeys = mediaKeys.stream()
                 .filter(key -> !validateMetadata(key))


### PR DESCRIPTION
<!-- 제목 양식 : prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 확인 --> 

## 🎉 Issue Number
<!-- #{본인 이슈 번호}로 이슈가 연결됩니다 -->
closes #9

## ✅ Done
<!-- 본인이 한 업무 -->

- [x] 허용되지 않는 이미지 삭제 시 null 처리

## ✍️ Description
<!-- 본인이 한 작업 설명 -->
<!-- 고민, 개선사항 포함 -->
- 기존의 메서드를 사용하여 리스트에 key를 전달하여 허용되지 않는 이미지를 삭제하는 방식을 사용했었습니다.
- List.of는 null 값을 전달하면, 에러가 발생하여 에러 처리를 포함한 새로운 메서드를 생성했습니다.