### PR TITLE
Feat [#11] 엑세스, 리프레시 토큰 전달 방식 변경

### DIFF
--- a/src/main/java/cotato/timetile/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/cotato/timetile/auth/filter/JwtAuthenticationFilter.java
@@ -5,30 +5,30 @@ import cotato.timetile.auth.UserPrincipal;
 import cotato.timetile.auth.jwt.JwtProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    private final static String HEADER_AUTHORIZATION = "Authorization";
-    private final static String TOKEN_PREFIX = "Bearer ";
+
+    private static final String ACCESS_TOKEN_COOKIE = "accessToken";
     private final JwtProvider jwtProvider;
     private final CustomUserDetailsService customUserDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
-        String token = getAccessToken(authorizationHeader);
+        String token = getAccessTokenFromCookie(request);
 
         if (jwtProvider.validateToken(token)) {
             Long userId = jwtProvider.getUserIdFromToken(token);
@@ -45,10 +45,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String getAccessToken(String authorizationHeader) {
-        if (StringUtils.hasText(authorizationHeader) && authorizationHeader.startsWith(TOKEN_PREFIX)) {
-            return authorizationHeader.substring(TOKEN_PREFIX.length());
+    private String getAccessTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return null;
         }
-        return null;
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> ACCESS_TOKEN_COOKIE.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
     }
+
 }

--- a/src/main/java/cotato/timetile/auth/filter/LocalAuthenticationFilter.java
+++ b/src/main/java/cotato/timetile/auth/filter/LocalAuthenticationFilter.java
@@ -5,9 +5,6 @@ import cotato.timetile.auth.CustomLoginFailureHandler;
 import cotato.timetile.auth.UserPrincipal;
 import cotato.timetile.auth.jwt.JwtProvider;
 import cotato.timetile.domain.user.api.request.LocalLoginRequest;
-import cotato.timetile.domain.user.api.response.LoginResponse;
-import cotato.timetile.global.common.CommonResponse;
-import cotato.timetile.global.common.SuccessResponse;
 import cotato.timetile.global.exception.UnauthorizedException;
 import cotato.timetile.global.properties.FrontendProperties;
 import jakarta.servlet.FilterChain;
@@ -15,9 +12,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -65,12 +62,23 @@ public class LocalAuthenticationFilter extends UsernamePasswordAuthenticationFil
         UserPrincipal userDetails = (UserPrincipal) authResult.getPrincipal();
         String refreshToken = jwtProvider.generateRefreshToken(userDetails.getId());
         String accessToken = jwtProvider.generateAccessToken(refreshToken);
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding(StandardCharsets.UTF_8.displayName());
-        response.getWriter().write(objectMapper.writeValueAsString(
-                CommonResponse.success(SuccessResponse.OK, LoginResponse.of(accessToken, refreshToken)))
-        );
+        ResponseCookie accessCookie = ResponseCookie.from("accessToken", accessToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(JwtProvider.ACCESS_TOKEN_VALID_DURATION)
+                .sameSite("Strict")
+                .build();
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(JwtProvider.REFRESH_TOKEN_VALID_DURATION)
+                .sameSite("Strict")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+        response.sendRedirect(frontendProperties.homeUrl());
     }
 
 }

--- a/src/main/java/cotato/timetile/auth/jwt/AccessTokenReissueController.java
+++ b/src/main/java/cotato/timetile/auth/jwt/AccessTokenReissueController.java
@@ -3,11 +3,10 @@ package cotato.timetile.auth.jwt;
 import cotato.timetile.global.common.CommonResponse;
 import cotato.timetile.global.common.SuccessResponse;
 import cotato.timetile.global.util.ApiResponseUtil;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,8 +18,8 @@ public class AccessTokenReissueController {
     private final RefreshTokenService refreshTokenService;
 
     @PostMapping(value = "/reissue")
-    public ResponseEntity<CommonResponse<?>> reissue(@Valid @RequestBody AccessTokenReissueRequest request) {
-        return ApiResponseUtil.success(SuccessResponse.CREATED, refreshTokenService.reissue(request));
+    public ResponseEntity<CommonResponse<?>> reissue(@CookieValue(name = "refreshToken") String refreshToken) {
+        return ApiResponseUtil.success(SuccessResponse.CREATED, refreshTokenService.reissue(refreshToken));
     }
 
 }

--- a/src/main/java/cotato/timetile/auth/jwt/JwtProvider.java
+++ b/src/main/java/cotato/timetile/auth/jwt/JwtProvider.java
@@ -22,8 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class JwtProvider {
 
-    private static final Duration REFRESH_TOKEN_VALID_DURATION = Duration.ofDays(14);
-    private static final Duration ACCESS_TOKEN_VALID_DURATION = Duration.ofHours(3);
+    public static final Duration REFRESH_TOKEN_VALID_DURATION = Duration.ofDays(14);
+    public static final Duration ACCESS_TOKEN_VALID_DURATION = Duration.ofHours(3);
     private static final String JWT_TYPE = "JWT";
     private static final String CLAIM_ROLE = "role";
     private static final String CLAIM_PROVIDER = "provider";

--- a/src/main/java/cotato/timetile/auth/jwt/RefreshTokenService.java
+++ b/src/main/java/cotato/timetile/auth/jwt/RefreshTokenService.java
@@ -11,10 +11,10 @@ public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
 
-    public AccessTokenReissueResponse reissue(AccessTokenReissueRequest request) {
-        RefreshToken refreshToken = refreshTokenRepository.findByRefreshToken(request.refreshToken())
+    public AccessTokenReissueResponse reissue(String refreshToken) {
+        RefreshToken token = refreshTokenRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(UnauthorizedException::invalid);
-        String accessToken = jwtProvider.generateAccessToken(refreshToken.getRefreshToken());
+        String accessToken = jwtProvider.generateAccessToken(token.getRefreshToken());
         return AccessTokenReissueResponse.of(accessToken);
     }
 

--- a/src/main/java/cotato/timetile/auth/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/cotato/timetile/auth/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,18 +1,14 @@
 package cotato.timetile.auth.oauth2;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import cotato.timetile.auth.UserPrincipal;
 import cotato.timetile.auth.jwt.JwtProvider;
-import cotato.timetile.domain.user.api.response.LoginResponse;
-import cotato.timetile.global.common.CommonResponse;
-import cotato.timetile.global.common.SuccessResponse;
 import cotato.timetile.global.properties.FrontendProperties;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -22,7 +18,6 @@ import org.springframework.stereotype.Component;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final FrontendProperties frontendProperties;
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private final JwtProvider jwtProvider;
 
     @Override
@@ -38,13 +33,24 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             Long userId = oAuth2User.getId();
             String refreshToken = jwtProvider.generateRefreshToken(userId);
             String accessToken = jwtProvider.generateAccessToken(refreshToken);
-            response.setStatus(HttpServletResponse.SC_OK);
-            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            response.setCharacterEncoding(StandardCharsets.UTF_8.displayName());
-            response.getWriter().write(objectMapper.writeValueAsString(CommonResponse.success(
-                    SuccessResponse.OK, LoginResponse.of(accessToken, refreshToken))));
+            ResponseCookie accessCookie = ResponseCookie.from("accessToken", accessToken)
+                    .httpOnly(true)
+                    .secure(true)
+                    .path("/")
+                    .maxAge(JwtProvider.ACCESS_TOKEN_VALID_DURATION)
+                    .sameSite("Strict")
+                    .build();
+            ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
+                    .httpOnly(true)
+                    .secure(true)
+                    .path("/")
+                    .maxAge(JwtProvider.REFRESH_TOKEN_VALID_DURATION)
+                    .sameSite("Strict")
+                    .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+            response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+            response.sendRedirect(frontendProperties.homeUrl());
         }
-
     }
 
 }


### PR DESCRIPTION
- 엑세스, 리프레시 토큰 전달 방식을 JSON에서 쿠키로 변경했습니다.

<!-- 제목 양식 : prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 확인 --> 

## 🎉 Issue Number
<!-- #{본인 이슈 번호}로 이슈가 연결됩니다 -->
closes #11 

## ✅ Done
<!-- 본인이 한 업무 -->

- [x] 엑세스, 리프레시 토큰 전달 방식 쿠키로 변경

## ✍️ Description
<!-- 본인이 한 작업 설명 -->
<!-- 고민, 개선사항 포함 -->
